### PR TITLE
Fjerne bug med at feil dato blir lagret

### DIFF
--- a/apps/frontend/src/components/Process/DateFieldsProcessModal.tsx
+++ b/apps/frontend/src/components/Process/DateFieldsProcessModal.tsx
@@ -1,6 +1,6 @@
 import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { Button, DatePicker, Tooltip, useDatepicker } from '@navikt/ds-react'
+import { Button, DatePicker, Tooltip } from '@navikt/ds-react'
 import { Field, FieldProps } from 'formik'
 import { useState } from 'react'
 import { IProcessFormValues } from '../../constants'
@@ -38,7 +38,6 @@ const LabelWithTooltip = (props: ILabelWithTooltipProps) => {
 export const DateFieldsProcessModal = (props: IDateModalProps) => {
   const { showLabels } = props
   const [showDates, setShowDates] = useState<boolean>(props.showDates)
-  const { datepickerProps, inputProps } = useDatepicker({})
 
   return (
     <>
@@ -76,7 +75,6 @@ export const DateFieldsProcessModal = (props: IDateModalProps) => {
                   <Field name="start">
                     {({ form }: FieldProps<string, IProcessFormValues>) => (
                       <DatePicker
-                        {...datepickerProps}
                         onSelect={(date: any) => {
                           const dateSingle: Date = Array.isArray(date) ? date[0] : date
                           if (dateSingle) {
@@ -88,7 +86,6 @@ export const DateFieldsProcessModal = (props: IDateModalProps) => {
                       >
                         <DatePicker.Input
                           className="mb-2"
-                          {...inputProps}
                           value={form.values['start']}
                           label="Velg fra og med dato"
                           error={!!form.errors.start && (form.touched.start || !!form.submitCount)}
@@ -104,7 +101,6 @@ export const DateFieldsProcessModal = (props: IDateModalProps) => {
                   <Field name="end">
                     {({ form }: FieldProps<string, IProcessFormValues>) => (
                       <DatePicker
-                        {...datepickerProps}
                         onSelect={(date: any) => {
                           const dateSingle: Date = Array.isArray(date) ? date[0] : date
                           if (dateSingle) {
@@ -116,7 +112,6 @@ export const DateFieldsProcessModal = (props: IDateModalProps) => {
                       >
                         <DatePicker.Input
                           className="mb-2"
-                          {...inputProps}
                           value={form.values['end']}
                           label="Velg til og med dato"
                           error={!!form.errors.end && (form.touched.end || !!form.submitCount)}

--- a/apps/frontend/src/components/Process/DateFieldsProcessModal.tsx
+++ b/apps/frontend/src/components/Process/DateFieldsProcessModal.tsx
@@ -1,11 +1,10 @@
 import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { Button, DatePicker, Tooltip } from '@navikt/ds-react'
-import { Field, FieldProps } from 'formik'
+import { Button, Tooltip } from '@navikt/ds-react'
 import { useState } from 'react'
-import { IProcessFormValues } from '../../constants'
 import { theme } from '../../util'
-import { Error } from '../common/ModalSchema'
+import { EndDate } from './EndDate'
+import { StartDate } from './StartDate'
 
 interface IDateModalProps {
   showDates: boolean
@@ -70,58 +69,9 @@ export const DateFieldsProcessModal = (props: IDateModalProps) => {
               </div>
             </div>
             <div className="flex w-full">
-              <div className="w-1/2 mr-4">
-                <div className="flex w-full mt-4">
-                  <Field name="start">
-                    {({ form }: FieldProps<string, IProcessFormValues>) => (
-                      <DatePicker
-                        onSelect={(date: any) => {
-                          const dateSingle: Date = Array.isArray(date) ? date[0] : date
-                          if (dateSingle) {
-                            const newDate = dateSingle.setDate(dateSingle.getDate() + 1)
-                            const formatedDate = new Date(newDate)
-                            form.setFieldValue('start', formatedDate.toISOString().split('T')[0])
-                          } else form.setFieldValue('start', undefined)
-                        }}
-                      >
-                        <DatePicker.Input
-                          className="mb-2"
-                          value={form.values['start']}
-                          label="Velg fra og med dato"
-                          error={!!form.errors.start && (form.touched.start || !!form.submitCount)}
-                        />
-                      </DatePicker>
-                    )}
-                  </Field>
-                </div>
-                <Error fieldName="start" />
-              </div>
-              <div className="w-1/2">
-                <div className="flex w-full mt-4">
-                  <Field name="end">
-                    {({ form }: FieldProps<string, IProcessFormValues>) => (
-                      <DatePicker
-                        onSelect={(date: any) => {
-                          const dateSingle: Date = Array.isArray(date) ? date[0] : date
-                          if (dateSingle) {
-                            const newDate = dateSingle.setDate(dateSingle.getDate() + 1)
-                            const formatedDate = new Date(newDate)
-                            form.setFieldValue('end', formatedDate.toISOString().split('T')[0])
-                          } else form.setFieldValue('end', undefined)
-                        }}
-                      >
-                        <DatePicker.Input
-                          className="mb-2"
-                          value={form.values['end']}
-                          label="Velg til og med dato"
-                          error={!!form.errors.end && (form.touched.end || !!form.submitCount)}
-                        />
-                      </DatePicker>
-                    )}
-                  </Field>
-                </div>
-                <Error fieldName="end" />
-              </div>
+              <StartDate />
+
+              <EndDate />
             </div>
           </div>
         </>

--- a/apps/frontend/src/components/Process/EndDate.tsx
+++ b/apps/frontend/src/components/Process/EndDate.tsx
@@ -1,0 +1,38 @@
+import { DatePicker, useDatepicker } from '@navikt/ds-react'
+import { Field, FieldProps } from 'formik'
+import { IProcessFormValues } from '../../constants'
+import { Error } from '../common/ModalSchema'
+
+export const EndDate = () => {
+  const { datepickerProps } = useDatepicker()
+
+  return (
+    <div className="w-1/2 mr-4">
+      <div className="flex w-full mt-4">
+        <Field name="end">
+          {({ form }: FieldProps<string, IProcessFormValues>) => (
+            <DatePicker
+              {...datepickerProps}
+              onSelect={(date: any) => {
+                const dateSingle: Date = Array.isArray(date) ? date[0] : date
+                if (dateSingle) {
+                  const newDate = dateSingle.setDate(dateSingle.getDate() + 1)
+                  const formatedDate = new Date(newDate)
+                  form.setFieldValue('end', formatedDate.toISOString().split('T')[0])
+                } else form.setFieldValue('end', undefined)
+              }}
+            >
+              <DatePicker.Input
+                className="mb-2"
+                value={form.values['end']}
+                label="Velg til og med dato"
+                error={!!form.errors.end && (form.touched.end || !!form.submitCount)}
+              />
+            </DatePicker>
+          )}
+        </Field>
+      </div>
+      <Error fieldName="end" />
+    </div>
+  )
+}

--- a/apps/frontend/src/components/Process/StartDate.tsx
+++ b/apps/frontend/src/components/Process/StartDate.tsx
@@ -1,0 +1,38 @@
+import { DatePicker, useDatepicker } from '@navikt/ds-react'
+import { Field, FieldProps } from 'formik'
+import { IProcessFormValues } from '../../constants'
+import { Error } from '../common/ModalSchema'
+
+export const StartDate = () => {
+  const { datepickerProps } = useDatepicker()
+
+  return (
+    <div className="w-1/2 mr-4">
+      <div className="flex w-full mt-4">
+        <Field name="start">
+          {({ form }: FieldProps<string, IProcessFormValues>) => (
+            <DatePicker
+              {...datepickerProps}
+              onSelect={(date: any) => {
+                const dateSingle: Date = Array.isArray(date) ? date[0] : date
+                if (dateSingle) {
+                  const newDate = dateSingle.setDate(dateSingle.getDate() + 1)
+                  const formatedDate = new Date(newDate)
+                  form.setFieldValue('start', formatedDate.toISOString().split('T')[0])
+                } else form.setFieldValue('start', undefined)
+              }}
+            >
+              <DatePicker.Input
+                className="mb-2"
+                value={form.values['start']}
+                label="Velg fra og med dato"
+                error={!!form.errors.start && (form.touched.start || !!form.submitCount)}
+              />
+            </DatePicker>
+          )}
+        </Field>
+      </div>
+      <Error fieldName="start" />
+    </div>
+  )
+}


### PR DESCRIPTION
Ved å fjerne datepickerProps så har vi løst problemet med at input blir lagret i feil felt. Det siste.
Aksel sine props klarer ikke å skille mellom hvilken felt som skal oppdateres selv om formik har god oversikt. Ved å har fjernet prop'ene så har vi mistet automatisk stenging av modal. Dette må vi fikse.