### PR TITLE
fix: update testcontainers PostgreSQL artifact ID for v2.x

### DIFF
--- a/apps/backend/polly-test/pom.xml
+++ b/apps/backend/polly-test/pom.xml
@@ -60,7 +60,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
+            <artifactId>testcontainers-postgresql</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/apps/backend/pom.xml
+++ b/apps/backend/pom.xml
@@ -44,7 +44,7 @@
         <stax2-api.version>4.2.2</stax2-api.version>
 
         <!-- Test -->
-        <testcontainers.version>1.21.4</testcontainers.version>
+        <testcontainers.version>2.0.4</testcontainers.version>
         <wiremock.version>3.13.2</wiremock.version>
     </properties>
 


### PR DESCRIPTION
Rename org.testcontainers:postgresql to org.testcontainers:testcontainers-postgresql in polly-test/pom.xml to match the new module naming convention introduced in testcontainers 2.0.4.