### PR TITLE
Bump msal4j 1.23.1 → 1.24.1 and fix OAuth callback for FORM_POST

### DIFF
--- a/apps/backend/polly-app/src/main/java/no/nav/data/common/security/AuthController.java
+++ b/apps/backend/polly-app/src/main/java/no/nav/data/common/security/AuthController.java
@@ -1,6 +1,33 @@
 package no.nav.data.common.security;
 
 
+import static no.nav.data.common.security.SecurityConstants.COOKIE_NAME;
+import static no.nav.data.common.utils.Constants.SESSION_LENGTH;
+import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.CODE;
+import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.ERROR;
+import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.ERROR_DESCRIPTION;
+import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.ERROR_URI;
+import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.REDIRECT_URI;
+import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.STATE;
+import static org.springframework.security.web.util.UrlUtils.buildFullRequestUrl;
+
+import java.io.IOException;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.DefaultRedirectStrategy;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -14,31 +41,6 @@ import no.nav.data.common.exceptions.TechnicalException;
 import no.nav.data.common.security.dto.OAuthState;
 import no.nav.data.common.security.dto.UserInfo;
 import no.nav.data.common.security.dto.UserInfoResponse;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.DefaultRedirectStrategy;
-import org.springframework.security.web.RedirectStrategy;
-import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.util.UriComponentsBuilder;
-
-import java.io.IOException;
-
-import static no.nav.data.common.security.SecurityConstants.COOKIE_NAME;
-import static no.nav.data.common.utils.Constants.SESSION_LENGTH;
-import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.CODE;
-import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.ERROR;
-import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.ERROR_DESCRIPTION;
-import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.ERROR_URI;
-import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.REDIRECT_URI;
-import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.STATE;
-import static org.springframework.security.web.util.UrlUtils.buildFullRequestUrl;
 
 @Slf4j
 @RestController
@@ -72,7 +74,7 @@ public class AuthController {
     @Operation(summary = "oidc callback")
     @ApiResponse(responseCode = "302", description = "token accepted")
     @CrossOrigin
-    @GetMapping(OAUTH_2_CALLBACK_URL)
+    @PostMapping(OAUTH_2_CALLBACK_URL)
     public void oidc(HttpServletRequest request, HttpServletResponse response,
             @RequestParam(value = CODE, required = false) String code,
             @RequestParam(value = ERROR, required = false) String error,

--- a/apps/backend/polly-app/src/main/java/no/nav/data/common/security/azure/AzureTokenProvider.java
+++ b/apps/backend/polly-app/src/main/java/no/nav/data/common/security/azure/AzureTokenProvider.java
@@ -1,5 +1,27 @@
 package no.nav.data.common.security.azure;
 
+import static java.util.Objects.requireNonNull;
+import static no.nav.data.common.security.SecurityConstants.SESS_ID_LEN;
+import static no.nav.data.common.security.SecurityConstants.TOKEN_TYPE;
+import static no.nav.data.common.security.azure.AzureConstants.MICROSOFT_GRAPH_SCOPES;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URL;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
+
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.microsoft.aad.msal4j.AuthorizationCodeParameters;
@@ -16,6 +38,7 @@ import com.microsoft.kiota.authentication.AccessTokenProvider;
 import com.microsoft.kiota.authentication.AllowedHostsValidator;
 import com.microsoft.kiota.authentication.BaseBearerTokenAuthenticationProvider;
 import com.nimbusds.oauth2.sdk.pkce.CodeChallengeMethod;
+
 import io.prometheus.client.Summary;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.data.common.exceptions.TechnicalException;
@@ -28,27 +51,6 @@ import no.nav.data.common.security.dto.Credential;
 import no.nav.data.common.security.dto.OAuthState;
 import no.nav.data.common.utils.Constants;
 import no.nav.data.common.utils.MetricUtils;
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.springframework.stereotype.Service;
-import org.springframework.util.Assert;
-import org.springframework.util.ReflectionUtils;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.net.URI;
-import java.net.URL;
-import java.time.Duration;
-import java.util.Map;
-import java.util.Set;
-
-import static java.util.Objects.requireNonNull;
-import static no.nav.data.common.security.SecurityConstants.SESS_ID_LEN;
-import static no.nav.data.common.security.SecurityConstants.TOKEN_TYPE;
-import static no.nav.data.common.security.azure.AzureConstants.MICROSOFT_GRAPH_SCOPES;
 
 @Slf4j
 @Service
@@ -145,7 +147,7 @@ public class AzureTokenProvider implements TokenProvider {
         URL url = msalClient.getAuthorizationRequestUrl(AuthorizationRequestUrlParameters
                 .builder(redirectUri, MICROSOFT_GRAPH_SCOPES)
                 .state(new OAuthState(auth.getId().toString(), postLoginRedirectUri, postLoginErrorUri).toJson(encryptor))
-                .responseMode(ResponseMode.QUERY)
+                .responseMode(ResponseMode.FORM_POST)
                 .codeChallengeMethod(CodeChallengeMethod.S256.getValue())
                 .codeChallenge(codeChallenge)
                 .build());

--- a/apps/backend/pom.xml
+++ b/apps/backend/pom.xml
@@ -32,7 +32,7 @@
         <google-cloud-bigquery.version>2.38.2</google-cloud-bigquery.version>
 
         <microsoft-graph.version>6.64.0</microsoft-graph.version>
-        <msal4j.version>1.23.1</msal4j.version>
+        <msal4j.version>1.24.1</msal4j.version>
         <graphql.version>24.0</graphql.version>
 
         <!-- transitive versions -->


### PR DESCRIPTION
msal4j 1.24.0 deprecated ResponseMode.QUERY and silently overrides it to FORM_POST, which broke login since the callback was a GET endpoint.

- Switch ResponseMode.QUERY → FORM_POST
- Change callback from @GetMapping to @PostMapping